### PR TITLE
NPC Door Queue

### DIFF
--- a/Assets/Scripts/GameSystems/ObjectiveController.cs
+++ b/Assets/Scripts/GameSystems/ObjectiveController.cs
@@ -11,8 +11,8 @@ public class ObjectiveController : MonoBehaviour, IDataPersistence
     [SerializeField] private TextMeshProUGUI historicStatDisplay;
     [SerializeField] private Transform objectiveParent;
 
-    public static int totalObjectives = 11;
-    public static int objectivesComplete = 0;
+    public int totalObjectives = 11;
+    public int objectivesComplete = 0;
     private int objectivesCompleteAllTime = 0;
 
     private static bool allObjectivesComplete = false;

--- a/Assets/Scripts/GameSystems/Objectives/Objective.cs
+++ b/Assets/Scripts/GameSystems/Objectives/Objective.cs
@@ -24,7 +24,7 @@ public class Objective : MonoBehaviour
         objectiveUI.sprite = completedIcon;
         objectiveUI.color = Color.white;
         isComplete = true;
-        if(completionThought != string.Empty && ObjectiveController.objectivesComplete > 2) 
+        if(completionThought != string.Empty) 
             Invoke(nameof(FollowUpThought), TIMETILLTHOUGHT);
     }
 

--- a/Assets/Scripts/GameSystems/TimeController.cs
+++ b/Assets/Scripts/GameSystems/TimeController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 
@@ -31,6 +32,7 @@ public class TimeController : MonoBehaviour, IDataPersistence
 
     [Header("Events")]
     public Transform scheduledEvents;
+    [SerializeField] Transform doorEventLocation;
     //[SerializeField] private List<TimedEvent> scheduledEvents;
 
     private float timeMultiplier;
@@ -77,6 +79,43 @@ public class TimeController : MonoBehaviour, IDataPersistence
     {
         foreach (Transform eventTransform in scheduledEvents)
         {
+            // Diff logic for neighbourhood appearences to ensure no conflicts
+            if(eventTransform.TryGetComponent(out NeighbourAppearance ne))
+            {
+                if (doorEventLocation == ne.endPosition)
+                {
+                    if (IsNextInQueue(ne))
+                    {
+                        if (ne.ShouldEventTrigger())
+                        {
+                            ne.TriggerEvent();
+                            ne.hasBeenTriggered = true;
+                        }
+                        else if (ne.ShouldEventEndTrigger())
+                        {
+                            ne.TriggerEventEnd();
+                            ne.eventHasEnded = true;
+                        }
+                    }
+                    else
+                    {
+                        if (ne.ShouldEventTrigger())
+                        {
+                            if (ne.cachedEndHour == null) ne.cachedEndHour = ne.eventEndHour;
+                            if (ne.cachedEndMinute == null) ne.cachedEndMinute = ne.eventEndMinute;
+
+                            TimeSpan eventStartTs = new(ne.eventHour, ne.eventMinute, 0);
+                            TimeSpan newEnd = new(ne.cachedEndHour.Value, ne.cachedEndMinute.Value, 0);
+
+                            newEnd = newEnd.Add(TimeSpan.FromSeconds(time).Subtract(eventStartTs));
+
+                            ne.SetEventEndTime(newEnd.Hours, newEnd.Minutes);
+                        }
+                    }
+                    continue;
+                }
+            }
+
             if (eventTransform.TryGetComponent(out TimedEvent e))
             {
                 if (e.ShouldEventTrigger())
@@ -95,6 +134,27 @@ public class TimeController : MonoBehaviour, IDataPersistence
                 }
             }
         }
+    }
+
+    private bool IsNextInQueue(NeighbourAppearance appearance)
+    {
+        List<NeighbourAppearance> list = new List<NeighbourAppearance>();
+        foreach (Transform eventTransform in scheduledEvents)
+        {
+            if (eventTransform.TryGetComponent(out NeighbourAppearance e))
+            {
+                if (!e.eventHasEnded)
+                {
+                    list.Add(e);
+                }
+            }
+        }
+
+        if (list.Count == 0) return false;
+
+        list = list.OrderBy(o => o.GetScheduledStartTime()).ToList();
+
+        return list[0] == appearance;
     }
 
     public void TurnOffAllLights()

--- a/Assets/Scripts/Interactables/Fire.cs
+++ b/Assets/Scripts/Interactables/Fire.cs
@@ -27,7 +27,7 @@ public class Fire : Interactable, IDataPersistence
         if(wasLit)
         {
             LightFire();
-            Interact();
+            DouseFire();
         }
 
     }
@@ -80,11 +80,7 @@ public class Fire : Interactable, IDataPersistence
 
     public override void Interact()
     {
-        isLit = false;
-        fireLight.intensity = 0f;
-        SetParticleEmission(fireParticles, 0f);
-        SetParticleEmission(smokeParticles, smokeMaxEmission);
-        smokeTimer = smokeLife;
+        DouseFire();
 
         int firesLit = 0;
         foreach(Fire fire in FindObjectsOfType<Fire>())
@@ -93,6 +89,15 @@ public class Fire : Interactable, IDataPersistence
             ThoughtBubble.Instance.ShowThought(PUTOUTTHOUGHT);
 
     }
+
+    private void DouseFire()
+    {
+        isLit = false;
+        fireLight.intensity = 0f;
+        SetParticleEmission(fireParticles, 0f);
+        SetParticleEmission(smokeParticles, smokeMaxEmission);
+        smokeTimer = smokeLife;
+    } 
 
     public override bool CanInteract()
     {

--- a/Assets/Scripts/TimeEvents/LimitedTimedEvent.cs
+++ b/Assets/Scripts/TimeEvents/LimitedTimedEvent.cs
@@ -5,9 +5,9 @@ using UnityEngine;
 public class LimitedTimedEvent : TimedEvent
 {
     [Range(0, 23)]
-    [SerializeField] protected int eventEndHour;
+    public int eventEndHour;
     [Range(0, 59)]
-    [SerializeField] protected int eventEndMinute;
+    public int eventEndMinute;
 
     public bool eventHasEnded = false;
 

--- a/Assets/Scripts/TimeEvents/NeighbourAppearance.cs
+++ b/Assets/Scripts/TimeEvents/NeighbourAppearance.cs
@@ -25,7 +25,7 @@ public class NeighbourAppearance : LimitedTimedEvent, IDataPersistence
 
     public void LoadData(GameData data)
     {
-        destinationReachedTriggered = data.hasNeighbourEventTriggered;
+        //destinationReachedTriggered = data.hasNeighbourEventTriggered;
     }
 
     public void SaveData(ref GameData data)

--- a/Assets/Scripts/TimeEvents/NeighbourAppearance.cs
+++ b/Assets/Scripts/TimeEvents/NeighbourAppearance.cs
@@ -10,6 +10,9 @@ public class NeighbourAppearance : LimitedTimedEvent
     private bool destinationReachedTriggered = false;
     private bool hasReturned = false;
 
+    public int? cachedEndHour;
+    public int? cachedEndMinute;
+
     public NavMeshAgent neighbour;
     public Transform endPosition;
     private NPC neighbourNPC;
@@ -38,7 +41,6 @@ public class NeighbourAppearance : LimitedTimedEvent
 
         if (AtStartPoint() && destinationReachedTriggered && !hasReturned)
         {
-            Debug.Log("jjjsdkfjhsdjk");
             OnReturn();
         }
     }
@@ -60,6 +62,7 @@ public class NeighbourAppearance : LimitedTimedEvent
         neighbour.SetDestination(startPosition);
         neighbourIsOut = false;
         neighbourNPC.FadeNPCAudioOut(5f);
+        eventHasEnded = true;
     }
 
     protected virtual void OnComplete()
@@ -79,14 +82,14 @@ public class NeighbourAppearance : LimitedTimedEvent
     {
         Vector2 neighbourXZ = new Vector2(neighbour.transform.position.x, neighbour.transform.position.z);
         Vector2 endXZ = new Vector2(endPosition.position.x, endPosition.position.z);
-        return Mathf.Round(Vector2.Distance(neighbourXZ, endXZ) * 10) == 0;
+        return Mathf.Round(Vector2.Distance(neighbourXZ, endXZ)) == 0;
     }
 
     private bool AtStartPoint()
     {
         Vector2 neighbourXZ = new Vector2(neighbour.transform.position.x, neighbour.transform.position.z);
         Vector2 endXZ = new Vector2(startPosition.x, startPosition.z);
-        return Mathf.Round(Vector2.Distance(neighbourXZ, endXZ) * 10) == 0;
+        return Mathf.Round(Vector2.Distance(neighbourXZ, endXZ)) == 0;
     }
     private void SetWalkingAnimationIfPresent(bool val)
     {
@@ -94,6 +97,11 @@ public class NeighbourAppearance : LimitedTimedEvent
         {
             animator.SetBool("isWalking", val);
         }
+    }
+
+    public string GetScheduledStartTime()
+    {
+        return eventHour.ToString() + eventMinute.ToString();
     }
 
 }

--- a/Assets/Scripts/TimeEvents/TimedEvent.cs
+++ b/Assets/Scripts/TimeEvents/TimedEvent.cs
@@ -5,9 +5,9 @@ using UnityEngine;
 public class TimedEvent : MonoBehaviour 
 {
     [Range(0,23)]
-    [SerializeField] protected int eventHour;
+    public int eventHour;
     [Range(0, 59)]
-    [SerializeField] protected int eventMinute;
+    public int eventMinute;
 
     public bool hasBeenTriggered = false;
 


### PR DESCRIPTION
Adds some slightly clunky code that runs separate logic for `NeighbourAppearenceEvent` classes.

The logic is essentially:
- rank the events that haven't ended by start time
- only check the event start/ends for those first in that queue
- if not first in the queue but the start time has passed, extend the end time so essentially they will stay at the door for the same length
