### PR TITLE
resets allObjectivesComplete on start

### DIFF
--- a/Assets/Scripts/GameSystems/EndGame.cs
+++ b/Assets/Scripts/GameSystems/EndGame.cs
@@ -84,7 +84,7 @@ public class EndGame : MonoBehaviour
         TimeController.Instance.ToggleTimePause();
         Player.Instance.TogglePlayerIsEngaged();
 
-        if (ObjectiveController.HasCompletedAllObjectives())
+        if (ObjectiveController.allObjectivesComplete)
         {
             bgMusic.Pause();
             boombox.Pause();

--- a/Assets/Scripts/GameSystems/ObjectiveController.cs
+++ b/Assets/Scripts/GameSystems/ObjectiveController.cs
@@ -15,7 +15,7 @@ public class ObjectiveController : MonoBehaviour, IDataPersistence
     public int objectivesComplete = 0;
     private int objectivesCompleteAllTime = 0;
 
-    private static bool allObjectivesComplete = false;
+    public static bool allObjectivesComplete = false;
 
     private const string HISTSTATPREFIX = "Total spreads found ever: ";
     private const string FINALTHOUGHT = "Hey! I think I've finally spread enough to detox, maybe it's time to go to bed!";
@@ -39,6 +39,7 @@ public class ObjectiveController : MonoBehaviour, IDataPersistence
 
     private void Start()
     {
+        allObjectivesComplete = false;
         totalObjectives = objectiveParent.childCount;
         scoreDisplay.text = objectivesComplete.ToString() + "/" + totalObjectives.ToString();
         historicStatDisplay.text = HISTSTATPREFIX + (objectivesCompleteAllTime + objectivesComplete);
@@ -66,10 +67,5 @@ public class ObjectiveController : MonoBehaviour, IDataPersistence
     {
         data.spreadEventsTriggered += objectivesComplete;
         data.numCompleteEvents = ObjectivesComplete;
-    }
-
-    public static bool HasCompletedAllObjectives()
-    {
-        return allObjectivesComplete;
     }
 }

--- a/Assets/Scripts/Interactables/Bed.cs
+++ b/Assets/Scripts/Interactables/Bed.cs
@@ -6,7 +6,7 @@ public class Bed : LockinInteractable
 
     protected override void FreeInteract()
     {
-        if (!ObjectiveController.HasCompletedAllObjectives())
+        if (!ObjectiveController.allObjectivesComplete)
         {
             base.FreeInteract();
             TimeController.Instance.tempMultiplier = restTimeMultiplier;


### PR DESCRIPTION
Ensures if you restart the game with all objectives complete, it doesn't allow you to instantly go to credits through resting