### PR TITLE
Explicit engaged setting

### DIFF
--- a/Assets/Scenes/Apartment.unity
+++ b/Assets/Scenes/Apartment.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311947, g: 0.38074014, b: 0.3587274, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -75838,9 +75838,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6146cb96381b457449a65394a80b5323, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  computerUI: {fileID: 147846116}
   pauseUI: {fileID: 1061140216}
-  phoneUI: {fileID: 43847456}
 --- !u!1 &1167937728
 GameObject:
   m_ObjectHideFlags: 0
@@ -95842,7 +95840,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fileName: its_spreading.game
-  useEncryption: 1
+  useEncryption: 0
 --- !u!1 &1454415444
 GameObject:
   m_ObjectHideFlags: 0
@@ -135943,6 +135941,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1322463418}
     m_Modifications:
+    - target: {fileID: 23925555902367440, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 23925555902367440, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1745858127939018292, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
       propertyPath: computerAudio
       value: 
@@ -136099,6 +136105,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4076138846089629119, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4076138846089629119, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4271223457305206659, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
       propertyPath: m_Name
       value: Computer UI
@@ -136121,6 +136135,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4729447672265563483, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
       propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4850541793945475129, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4850541793945475129, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4850541793945475129, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4850541793945475129, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5418527778239752957, guid: 227b177118c84244bb07332d4ac1bdea, type: 3}

--- a/Assets/Scripts/GameSystems/EndGame.cs
+++ b/Assets/Scripts/GameSystems/EndGame.cs
@@ -82,7 +82,7 @@ public class EndGame : MonoBehaviour
     public void DayIsOver()
     {
         TimeController.Instance.ToggleTimePause();
-        Player.Instance.TogglePlayerIsEngaged();
+        Player.Instance.LockPlayerIfNotEngaged();
 
         if (ObjectiveController.HasCompletedAllObjectives())
         {

--- a/Assets/Scripts/GameSystems/StartGame.cs
+++ b/Assets/Scripts/GameSystems/StartGame.cs
@@ -35,7 +35,7 @@ public class StartGame : MonoBehaviour, IDataPersistence
     public void StartDayFresh()
     {
         Player.Instance.ForcePlayerToPosition(startPosition);
-        Player.Instance.TogglePlayerIsEngaged(true);
+        Player.Instance.LockPlayerIfNotEngaged(true);
         Player.Instance._animator.SetTrigger("stretch");
         CameraController.Instance.SetCameraZoom(5f, 0.5f);
         Invoke(nameof(WakeupThought), 4f);
@@ -64,7 +64,7 @@ public class StartGame : MonoBehaviour, IDataPersistence
     private void WakeupThought()
     {
         CameraController.Instance.SetCameraZoom(9f, 0.2f);
-        Player.Instance.TogglePlayerIsEngaged();
+        Player.Instance.FreePlayerIfEngaged();
         _thoughtBubble.ShowThought(PlayerThoughts.WakeUp);
     }
 }

--- a/Assets/Scripts/Interactables/Bathtub.cs
+++ b/Assets/Scripts/Interactables/Bathtub.cs
@@ -108,7 +108,7 @@ public class Bathtub : Interactable
                 _audioSource.PlayOneShot(waterEnter, 1f);
 
                 player.GetComponent<PlayerInteract>().persistSelectedInteractable = true;
-                player.TogglePlayerIsEngaged();
+                player.LockPlayerIfNotEngaged();
 
                 resetPosition = player.transform.position;
                 resetRotation = player.transform.rotation;
@@ -124,7 +124,7 @@ public class Bathtub : Interactable
                 player.transform.position = resetPosition;
                 player.transform.rotation = resetRotation;
 
-                player.TogglePlayerIsEngaged();
+                player.FreePlayerIfEngaged();
                 player.GetComponent<PlayerInteract>().persistSelectedInteractable = false;
 
                 promptText = DRAIN;

--- a/Assets/Scripts/Interactables/Computer.cs
+++ b/Assets/Scripts/Interactables/Computer.cs
@@ -35,7 +35,7 @@ public class Computer : LockinInteractable
         Player.Instance.transform.position = resetPosition;
         Player.Instance.transform.rotation = resetRotation;
 
-        Player.Instance.TogglePlayerIsEngaged();
+        Player.Instance.FreePlayerIfEngaged();
         Player.Instance.GetComponent<PlayerInteract>().persistSelectedInteractable = false;
         promptText = freePrompt;
 

--- a/Assets/Scripts/Interactables/LockinInteractable.cs
+++ b/Assets/Scripts/Interactables/LockinInteractable.cs
@@ -28,7 +28,7 @@ public class LockinInteractable : Interactable
         Player.Instance.transform.position = resetPosition;
         Player.Instance.transform.rotation = resetRotation;
 
-        Player.Instance.TogglePlayerIsEngaged();
+        Player.Instance.FreePlayerIfEngaged();
         Player.Instance.GetComponent<PlayerInteract>().persistSelectedInteractable = false;
         promptText = freePrompt;
 
@@ -38,7 +38,7 @@ public class LockinInteractable : Interactable
     protected virtual void FreeInteract()
     {
         Player.Instance.GetComponent<PlayerInteract>().persistSelectedInteractable = true;
-        Player.Instance.TogglePlayerIsEngaged();
+        Player.Instance.LockPlayerIfNotEngaged();
 
         resetPosition = Player.Instance.transform.position;
         resetRotation = Player.Instance.transform.rotation;

--- a/Assets/Scripts/NPCs/DialogueNPC.cs
+++ b/Assets/Scripts/NPCs/DialogueNPC.cs
@@ -9,7 +9,7 @@ public class DialogueNPC : NPC
     public override void Interact()
     {
         TimeController.Instance.ToggleTimePause();
-        Player.Instance.TogglePlayerIsEngaged(true);
+        Player.Instance.LockPlayerIfNotEngaged(true);
         currentScheduler.npcIsEngaged = true;
         DialogueUI.Instance.LoadJsonConversationToUI(dialogueFile, this);
         DialogueUI.Instance.gameObject.SetActive(true);

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -216,7 +216,15 @@ public class Player : MonoBehaviour, IDataPersistence
         }
     }
 
-    
+    public void LockPlayerIfNotEngaged(bool shouldDisableInteract = false)
+    {
+        if (isUnengaged) TogglePlayerIsEngaged(shouldDisableInteract);
+    }
+
+    public void FreePlayerIfEngaged(bool shouldDisableInteract = false)
+    {
+        if (!isUnengaged) TogglePlayerIsEngaged(shouldDisableInteract);
+    }
 
     public void TogglePlayerIsEngaged(bool shouldDisableInteract = false)
     {

--- a/Assets/Scripts/SpreadingEvents/LoveSpreadingEvent.cs
+++ b/Assets/Scripts/SpreadingEvents/LoveSpreadingEvent.cs
@@ -49,7 +49,7 @@ public class LoveSpreadingEvent : SpreadingEvent
     private void CallSis()
     {
         TimeController.Instance.ToggleTimePause();
-        Player.Instance.TogglePlayerIsEngaged(true);
+        Player.Instance.LockPlayerIfNotEngaged(true);
         DialogueUI.Instance.LoadJsonConversationToUI(sisNPC.dialogueFile, sisNPC, 1);
         PhoneUI.Instance.TogglePhone();
 

--- a/Assets/Scripts/TimeEvents/EddyBeddyPodcastEvent.cs
+++ b/Assets/Scripts/TimeEvents/EddyBeddyPodcastEvent.cs
@@ -68,7 +68,8 @@ public class EddyBeddyPodcastEvent : LimitedTimedEvent, IDataPersistence
     private void TalkToEddy()
     {
         TimeController.Instance.ToggleTimePause();
-        Player.Instance.TogglePlayerIsEngaged(true);
+        Player.Instance.LockPlayerIfNotEngaged(true);
+        DialogueUI.Instance.playerEngagedPreConvo = !Player.Instance.isUnengaged;
         DialogueUI.Instance.LoadJsonConversationToUI(eddyBeddy.dialogueFile, eddyBeddy);
         PhoneUI.Instance.TogglePhone();
         hasTalkedToEddy = true;

--- a/Assets/Scripts/TimeEvents/SisterInteractionEvent.cs
+++ b/Assets/Scripts/TimeEvents/SisterInteractionEvent.cs
@@ -82,7 +82,8 @@ public class SisterInteractionEvent : LimitedTimedEvent
     private void CallSis()
     {
         TimeController.Instance.ToggleTimePause();
-        Player.Instance.TogglePlayerIsEngaged(true);
+        Player.Instance.LockPlayerIfNotEngaged(true);
+        DialogueUI.Instance.playerEngagedPreConvo = !Player.Instance.isUnengaged;
         DialogueUI.Instance.LoadJsonConversationToUI(sisNPC.dialogueFile, sisNPC);
         PhoneUI.Instance.TogglePhone();
         LoveSpreadingEvent.Instance.calledSisNoSuccess = true;

--- a/Assets/Scripts/UI/Dialogue/DialogueUI.cs
+++ b/Assets/Scripts/UI/Dialogue/DialogueUI.cs
@@ -26,6 +26,7 @@ public class DialogueUI : MonoBehaviour
     private NPCDialogue loadedNPCDialogue;
     private int currentConversationIndex = 0;
     public NPC currentNPC;
+    public bool playerEngagedPreConvo = false;
 
     private const string PORTRAITFOLDER = "CharacterPortraits/";
 

--- a/Assets/Scripts/UI/Dialogue/ResponseClasses/DeliveryResponse.cs
+++ b/Assets/Scripts/UI/Dialogue/ResponseClasses/DeliveryResponse.cs
@@ -6,7 +6,7 @@ public class DeliveryResponse : DialogueResponse
 {
     public override void CloseDialogue()
     {
-        Player.Instance.TogglePlayerIsEngaged();
+        Player.Instance.FreePlayerIfEngaged();
         DialogueUI.Instance.currentNPC.currentScheduler.TriggerEventEnd();
         base.CloseDialogue();
     }

--- a/Assets/Scripts/UI/Dialogue/ResponseClasses/EddyResponse.cs
+++ b/Assets/Scripts/UI/Dialogue/ResponseClasses/EddyResponse.cs
@@ -23,13 +23,15 @@ public class EddyResponse : DialogueResponse
     public override void CloseDialogue()
     {
         base.CloseDialogue();
-        Player.Instance.TogglePlayerIsEngaged();
+        if (!DialogueUI.Instance.playerEngagedPreConvo)
+            Player.Instance.FreePlayerIfEngaged();
         GossipSpreadingEvent.Instance.hasSpreadGossip = true;
     }
 
     public void CloseWithFailure()
     {
         base.CloseDialogue();
-        Player.Instance.TogglePlayerIsEngaged();
+        if (!DialogueUI.Instance.playerEngagedPreConvo)
+            Player.Instance.FreePlayerIfEngaged();
     }
 }

--- a/Assets/Scripts/UI/Dialogue/ResponseClasses/MissionaryResponse.cs
+++ b/Assets/Scripts/UI/Dialogue/ResponseClasses/MissionaryResponse.cs
@@ -20,7 +20,7 @@ public class MissionaryResponse : DialogueResponse
 
     public override void CloseDialogue()
     {
-        Player.Instance.TogglePlayerIsEngaged();
+        Player.Instance.FreePlayerIfEngaged();
         DialogueUI.Instance.currentNPC.currentScheduler.TriggerEventEnd();
         base.CloseDialogue();
     }

--- a/Assets/Scripts/UI/Dialogue/ResponseClasses/SisResponse.cs
+++ b/Assets/Scripts/UI/Dialogue/ResponseClasses/SisResponse.cs
@@ -9,7 +9,8 @@ public class SisResponse : DialogueResponse
         LoveSpreadingEvent.Instance.calledSis = true;
         LoveSpreadingEvent.Instance.calledSisNoSuccess = false;
         LoveSpreadingEvent.Instance.wasKindToSis = true;
-        Player.Instance.TogglePlayerIsEngaged();
+        if (!DialogueUI.Instance.playerEngagedPreConvo)
+            Player.Instance.FreePlayerIfEngaged();
         CloseDialogue();
         ThoughtBubble.Instance.ShowThought(PlayerThoughts.SuccessfulSisCall);
     }
@@ -18,14 +19,16 @@ public class SisResponse : DialogueResponse
     {
         LoveSpreadingEvent.Instance.calledSis = true;
         LoveSpreadingEvent.Instance.wasKindToSis = false;
-        Player.Instance.TogglePlayerIsEngaged();
+        if (!DialogueUI.Instance.playerEngagedPreConvo)
+            Player.Instance.FreePlayerIfEngaged();
         CloseDialogue();
     }
 
     public void CloseWithSpread()
     {
         LoveSpreadingEvent.Instance.gaveTicketsToSis = true;
-        Player.Instance.TogglePlayerIsEngaged();
+        if (!DialogueUI.Instance.playerEngagedPreConvo)
+            Player.Instance.FreePlayerIfEngaged();
         CloseDialogue();
     }
 }


### PR DESCRIPTION
Before, whenever you wanted to lock a player (for an interact or conversation) you called a toggle function. Because some of these interactions can overlap you can screw with the logic (and cause a bunch of bugs)

This makes it explicit when it wants to LOCK the player vs when it wants to FREE the player.

Specifically fixes taking calls whilst sat or in bed from freeing you during the conversation